### PR TITLE
Fix NPM publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - run: npm publish --access public
         env:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "declaration": true,
+    "skipLibCheck": true,
   },
   "include": [
     "./src/**/*",


### PR DESCRIPTION
## Summary
- use `npm install` instead of `npm ci` to avoid missing lockfile errors
- skip type checking of Node modules

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6887bcab53b08323914bca9a2aac56df