### PR TITLE
Add fbclid support

### DIFF
--- a/src/components/FBPixelProvider.tsx
+++ b/src/components/FBPixelProvider.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { fbPageView } from '../conversion-api';
+import Cookies from 'universal-cookie';
 
 type Props = {
   children: React.ReactNode
@@ -10,6 +11,20 @@ const FBPixelProvider = ({ children }: Props) => {
   const router = useRouter();
 
   useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (url.searchParams.has('fbclid')) {
+        const cookies = new Cookies();
+        if (!cookies.get('_fbc')) {
+          const fbclid = url.searchParams.get('fbclid');
+          if (fbclid) {
+            const timestamp = Math.floor(Date.now() / 1000);
+            cookies.set('_fbc', `fb.1.${timestamp}.${fbclid}`, { path: '/' });
+          }
+        }
+      }
+    }
+
     fbPageView();
 
     router.events.on('routeChangeComplete', fbPageView);

--- a/src/handlers/event-handler.ts
+++ b/src/handlers/event-handler.ts
@@ -18,6 +18,8 @@ type Arguments = {
   }[]
   value?: number
   currency?: string
+  fbp?: string
+  fbc?: string
   userAgent: string
   sourceUrl: string
   testEventCode?: string
@@ -58,6 +60,8 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     products,
     value,
     currency,
+    fbp,
+    fbc,
     userAgent,
     sourceUrl,
     testEventCode,
@@ -82,8 +86,8 @@ const eventHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     products,
     value,
     currency,
-    fbp: getClientFbp(req),
-    fbc: getClientFbc(req),
+    fbp: fbp || getClientFbp(req),
+    fbc: fbc || getClientFbc(req),
     ipAddress: getClientIpAddress(req),
     userAgent,
     sourceUrl,

--- a/src/services/server-side-events.ts
+++ b/src/services/server-side-events.ts
@@ -18,8 +18,8 @@ type Arguments = {
   }[]
   value?: number
   currency?: string
-  fbp: string
-  fbc: string
+  fbp?: string
+  fbc?: string
   ipAddress: string
   userAgent: string
   sourceUrl: string
@@ -107,8 +107,8 @@ const sendServerSideEvent = async ({
       ...(zipCode && {
         zp: (sha256Hash(zipCode)),
       }),
-      fbc,
-      fbp,
+      ...(fbc && { fbc }),
+      ...(fbp && { fbp }),
     },
     ...(products && products.length > 0) && {
       content_type: 'product',

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,5 +15,7 @@ export type FBEvent = {
   value?: number
   currency?: string
   enableStandardPixel?: boolean
+  fbp?: string
+  fbc?: string
   testEventCode?: string
 };


### PR DESCRIPTION
## Summary
- capture `fbclid` query param and persist as `_fbc` cookie
- send `_fbp` and `_fbc` values with events
- fall back to cookies on the backend if payload lacks these fields
- guard client code to only run in the browser

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6889bfc3ad9483238ce1abe3da82f2f6